### PR TITLE
Removes hardcoding of absolute links with __base_url

### DIFF
--- a/views/admin/index.ejs
+++ b/views/admin/index.ejs
@@ -5,13 +5,13 @@
 	<div class="col-md-offset-2 col-md-8">
 		<ul style="list-style-type: none;">
 			<h4>List data</h4>
-			<li><a href="<%=base_url%>/admin/sessions"><span class="glyphicon glyphicon-eye-open"></span> View all sessions</a></li>
-			<li><a href="<%=base_url%>/admin/users"><span class="glyphicon glyphicon-eye-open"></span> View all users</a></li>
-			<li><a href="<%=base_url%>/admin/rooms"><span class="glyphicon glyphicon-eye-open"></span> View all rooms</a></li>
-			<li><a href="<%=base_url%>/admin/probs"><span class="glyphicon glyphicon-eye-open"></span> View all problems</a></li>
+			<li><a href="/admin/sessions"><span class="glyphicon glyphicon-eye-open"></span> View all sessions</a></li>
+			<li><a href="/admin/users"><span class="glyphicon glyphicon-eye-open"></span> View all users</a></li>
+			<li><a href="/admin/rooms"><span class="glyphicon glyphicon-eye-open"></span> View all rooms</a></li>
+			<li><a href="/admin/probs"><span class="glyphicon glyphicon-eye-open"></span> View all problems</a></li>
 			<hr/>
 			<h4>Danger zone</h4>
-			<li><a href="<%=base_url%>/admin/delete_guests" id="delete-guests" class="label label-danger"><span class="glyphicon glyphicon-flash"></span> Delete all guest users</a></li>
+			<li><a href="/admin/delete_guests" id="delete-guests" class="label label-danger"><span class="glyphicon glyphicon-flash"></span> Delete all guest users</a></li>
 		</ul>	
 	</div>
 </div>

--- a/views/admin/probs.ejs
+++ b/views/admin/probs.ejs
@@ -19,10 +19,10 @@
 		  	<td><%= probs[i].title%></td>
 		  	<td><%= months[probs[i].date.getMonth()] + " " +probs[i].date.getDate() + ", " + probs[i].date.getFullYear()%></td>
 		  	<td><span class="glyphicon glyphicon-star" aria-hidden="true"></span>&nbsp;<%= probs[i].score %></td>
-		  	<td style="width:1%;"><a href="<%= base_url%>/prob/<%= probs[i].id%>" class="label label-success">View problem</a></td>
-		  	<td style="width:1%;"><a href="<%= base_url%>/room/<%= probs[i].room%>" class="label label-success">View room</a></td>
-			<td style="width:1%;"><a href="<%=base_url%>/prob/edit/<%=probs[i].id%>" class="label label-info">Edit</a></td>
-			<td style="width:1%;"><a href="<%=base_url%>/prob/delete/<%=probs[i].id%>" class="label label-danger delete-prob">Delete</a></td>
+		  	<td style="width:1%;"><a href="/prob/<%= probs[i].id%>" class="label label-success">View problem</a></td>
+		  	<td style="width:1%;"><a href="/room/<%= probs[i].room%>" class="label label-success">View room</a></td>
+			<td style="width:1%;"><a href="/prob/edit/<%=probs[i].id%>" class="label label-info">Edit</a></td>
+			<td style="width:1%;"><a href="/prob/delete/<%=probs[i].id%>" class="label label-danger delete-prob">Delete</a></td>
 		</tr>
 		<% } %>
 	</table>

--- a/views/admin/rooms.ejs
+++ b/views/admin/rooms.ejs
@@ -14,11 +14,11 @@
 		<% for(var i=0; i<rooms.length; i++) {%>
 		<tr>
 			<td><%= rooms[i].room %></td>
-		  	<td><a href="<%= __base_url + "/room/" + rooms[i].room %>"><%= rooms[i].title %></a></td>
+		  	<td><a href="/room/<%= rooms[i].room %>"><%= rooms[i].title %></a></td>
 		  	<td><%= months[rooms[i].date.getMonth()] + " " +rooms[i].date.getDate() + ", " + rooms[i].date.getFullYear()%></td>
 		  	<td><span class="glyphicon glyphicon-star" aria-hidden="true"></span>&nbsp;<%= rooms[i].points %></td>
-			<td style="width:1%;"><a href="<%=base_url%>/room/edit/<%=rooms[i].room%>" class="label label-info">Edit</a></td>
-			<td style="width:1%;"><a href="<%=base_url%>/room/delete/<%=rooms[i].room%>" class="label label-danger delete-room">Delete</a></td>
+			<td style="width:1%;"><a href="/room/edit/<%=rooms[i].room%>" class="label label-info">Edit</a></td>
+			<td style="width:1%;"><a href="/room/delete/<%=rooms[i].room%>" class="label label-danger delete-room">Delete</a></td>
 		</tr>
 		<% } %>
 	</table>

--- a/views/admin/sessions.ejs
+++ b/views/admin/sessions.ejs
@@ -14,7 +14,7 @@
 				<td><%= i+1 %></td>
 				<td><%= sessions[i].key%></td>
 				<td><%= sessions[i].nickname%></td>
-				<td style="width:1%;"><a href="<%= base_url%>/session/<%=sessions[i].key%>" class="label label-danger delete-session">Delete</td>
+				<td style="width:1%;"><a href="/session/<%=sessions[i].key%>" class="label label-danger delete-session">Delete</td>
 		</tr>
 		<% } %>
 	</table>

--- a/views/admin/users.ejs
+++ b/views/admin/users.ejs
@@ -34,9 +34,9 @@
 						<%}
 					}%>
 				</td>
-				<td style="width:1%;"><a href="<%= base_url%>/user/profile/<%=users[i].nickname%>" class="label label-success">View</td>
-				<td style="width:1%;"><a href="<%= base_url%>/user/edit/<%=users[i].nickname%>" class="label label-info">Edit</td>
-				<td style="width:1%;"><a href="<%= base_url%>/user/delete/<%=users[i].nickname%>" class="label label-danger delete-user">Delete</td>
+				<td style="width:1%;"><a href="/user/profile/<%=users[i].nickname%>" class="label label-success">View</td>
+				<td style="width:1%;"><a href="/user/edit/<%=users[i].nickname%>" class="label label-info">Edit</td>
+				<td style="width:1%;"><a href="/user/delete/<%=users[i].nickname%>" class="label label-danger delete-user">Delete</td>
 		</tr>
 		<% } %>
 	</table>

--- a/views/install/index.ejs
+++ b/views/install/index.ejs
@@ -22,7 +22,7 @@
 			</div>
 			<div class="text-danger form-group">* Required field</div>
 			<button type="submit" class="btn btn-default">Make Admin</button>
-			<a href="<%=base_url%>" class="btn btn-default">Cancel</a>
+			<a href="/" class="btn btn-default">Cancel</a>
 		</form>
 	</div>
 </div>

--- a/views/prob/create.ejs
+++ b/views/prob/create.ejs
@@ -36,7 +36,7 @@
 
 			<div class="text-danger form-group">* Required field</div>
 			<button type="submit" class="btn btn-default">Create problem</button>
-			<a href="<%= base_url%>" class="btn btn-default">Cancel</a>
+			<a href="/" class="btn btn-default">Cancel</a>
 		</form>
 	</div>
 </div>

--- a/views/prob/edit.ejs
+++ b/views/prob/edit.ejs
@@ -3,7 +3,7 @@
 		<br>
 		<h3 >Edit problem</h3>
 		<br>
-		<form method="POST" action="<%=base_url%>/prob/edit/<%=prob.id%>">
+		<form method="POST" action="/prob/edit/<%=prob.id%>">
 
 			<% if(typeof success_msg != 'undefined') { %>
 			<div class="top-messages bg-success"><%= success_msg %></div>
@@ -37,7 +37,7 @@
 
 			<div class="text-danger form-group">* Required field</div>
 			<button type="submit" class="btn btn-default">Save</button>
-			<a href="<%= base_url%>/prob/<%=prob.id%>" class="btn btn-default">Cancel</a>
+			<a href="/prob/<%=prob.id%>" class="btn btn-default">Cancel</a>
 		</form>
 	</div>
 </div>

--- a/views/prob/index.ejs
+++ b/views/prob/index.ejs
@@ -2,7 +2,7 @@
 	<br><br>
 	<div class="panel panel-default">
 	  <!-- Default panel contents -->
-	  <div class="panel-heading"><strong><%= prob.title %></strong> <% if(user.level == level.ADMIN){%><a href="<%=base_url%>/prob/edit/<%=prob.id%>" class="label label-info">Edit problem</a><%}%><span class="label label-success right"><%= prob.score %> points</span></div>
+	  <div class="panel-heading"><strong><%= prob.title %></strong> <% if(user.level == level.ADMIN){%><a href="/prob/edit/<%=prob.id%>" class="label label-info">Edit problem</a><%}%><span class="label label-success right"><%= prob.score %> points</span></div>
 	  <div class="panel-body">
 	    <p><%- prob.description %></p>
 	  </div>
@@ -25,11 +25,11 @@
 	    	<span class="glyphicon glyphicon-flag" aria-hidden="true"></span>&nbsp;&nbsp;Pending review
 	    </div>
 	    <% } else { %>
-	    <a href="<%= __base_url %>/prob/review/<%= prob.id %>" class="list-group-item">
+	    <a href="/prob/review/<%= prob.id %>" class="list-group-item">
 	    	<span class="glyphicon glyphicon-flag" aria-hidden="true"></span>&nbsp;&nbsp;Ask for solution review 
 	    </a>
 	    <% } %>
-	    <a href="<%= __base_url %>/room/<%= prob.room %>" class="list-group-item">
+	    <a href="/room/<%= prob.room %>" class="list-group-item">
 	    	<span class="glyphicon glyphicon-arrow-left" aria-hidden="true"></span>&nbsp;&nbsp;Back to room 
 	    </a>
 	  </div>

--- a/views/room/all.ejs
+++ b/views/room/all.ejs
@@ -13,7 +13,7 @@
 			<tr>
 				<td><%= rooms[i].room %></td>
 		  	<td>
-					<a href="<%= __base_url + "/room/" + rooms[i].room %>"><%= rooms[i].title %></a>
+					<a href="/room/<%= rooms[i].room %>"><%= rooms[i].title %></a>
 				</td>
 		  	<td><%= months[rooms[i].date.getMonth()] + " " +rooms[i].date.getDate() + ", " + rooms[i].date.getFullYear()%></td>
 		  	<td><span class="glyphicon glyphicon-star" aria-hidden="true"></span>&nbsp;<%= rooms[i].points %></td>

--- a/views/room/create.ejs
+++ b/views/room/create.ejs
@@ -24,7 +24,7 @@
 			</div>
 			<div class="text-danger form-group">* Required field</div>
 			<button type="submit" class="btn btn-default">Create room</button>
-			<a href="<%= base_url%>" class="btn btn-default">Cancel</a>
+			<a href="/" class="btn btn-default">Cancel</a>
 		</form>
 	</div>
 </div>

--- a/views/room/edit.ejs
+++ b/views/room/edit.ejs
@@ -4,7 +4,7 @@
 			<h3 >Edit room</h3>
 		</div>
 
-		<form method="POST" action="<%=base_url%>/room/edit/<%=room.room%>">
+		<form method="POST" action="/room/edit/<%=room.room%>">
 
 			<% if(typeof success_msg != 'undefined') { %>
 			<div class="top-messages bg-success"><%= success_msg %></div>
@@ -24,7 +24,7 @@
 			</div>
 			<div class="text-danger form-group">* Required field</div>
 			<button type="submit" class="btn btn-default">Save</button>
-			<a href="<%= base_url%>/room/<%=room.room%>" class="btn btn-default">Cancel</a>
+			<a href="/room/<%=room.room%>" class="btn btn-default">Cancel</a>
 		</form>
 	</div>
 </div>

--- a/views/room/index.ejs
+++ b/views/room/index.ejs
@@ -2,7 +2,7 @@
 	<br><br>
 	<div class="panel panel-default">
 	  <!-- Default panel contents -->
-	  <div class="panel-heading"><strong><%= room.title %></strong> <%if(user.level == level.ADMIN){%><a href="<%=base_url%>/room/edit/<%=room.room%>" class="label label-info">Edit room</a><%}%><span class="label label-success right"><%= room.points %> points</span></div>
+	  <div class="panel-heading"><strong><%= room.title %></strong> <%if(user.level == level.ADMIN){%><a href="/room/edit/<%=room.room%>" class="label label-info">Edit room</a><%}%><span class="label label-success right"><%= room.points %> points</span></div>
 	  <div class="panel-body">
 	    <p><%= room.description %></p>
 	  </div>
@@ -11,13 +11,13 @@
 	  <div class="panel-heading" style="border-top:1px solid rgb(221, 221, 221); border-radius:0px;">Problem List</div>
 	  <div class="list-group">
 	  	<% for(var i=0; i<probs.length; i++) {%>
-	  		<a href="<%= __base_url %>/prob/<%= probs[i].id %>" class="list-group-item" 
+	  		<a href="/prob/<%= probs[i].id %>" class="list-group-item" 
 	  		<% if(solved.indexOf(probs[i].id) != -1 ){%>style="background-color:#dff0d8"<% } %>><%=probs[i].title%>
 	  		<span class="right"><span class="glyphicon glyphicon-star" aria-hidden="true"></span>&nbsp;&nbsp;<%= probs[i].score%></span></a>
 	  	<% }%>
 
 	    <% if(user.level == level.ADMIN) { %>
-	    <a href="<%= __base_url %>/prob/create/<%= room.room %>" class="list-group-item">
+	    <a href="/prob/create/<%= room.room %>" class="list-group-item">
 	    	<span class="glyphicon glyphicon-plus" aria-hidden="true"></span>&nbsp;&nbsp;Add Problem
 	    </a>
 	    <% } %>

--- a/views/submissions/index.ejs
+++ b/views/submissions/index.ejs
@@ -13,8 +13,8 @@
 			</tr>	
 			<% for(var i=0; i<rels.length; i++) {%>
 				<tr>
-			  	<td><a href="<%=__base_url%>/prob/<%= rels[i].prob %>"><%= rels[i].prob_docs[0].title %></td>
-			  	<td><a href="<%=__base_url%>/room/<%= rels[i].prob_docs[0].room %>"><%= rels[i].prob_docs[0].room %></a></td>
+			  	<td><a href="/prob/<%= rels[i].prob %>"><%= rels[i].prob_docs[0].title %></td>
+			  	<td><a href="/room/<%= rels[i].prob_docs[0].room %>"><%= rels[i].prob_docs[0].room %></a></td>
 			  	<td><%= rels[i].user_docs[0].fullname %></td>
 			  	<td><%= months[rels[i].date.getMonth()] + " " +rels[i].date.getDate() + ", " + rels[i].date.getFullYear() + " at " + rels[i].date.getHours() + ":" + rels[i].date.getMinutes() + ":" + rels[i].date.getSeconds()%></td>
 			  	<td>
@@ -25,8 +25,8 @@
 						    Mark as... <span class="caret"></span>
 						  </button>
 						  <ul class="dropdown-menu">
-						    <li><a href="<%=__base_url%>/prob/complete/<%= rels[i]._id %>">Complete</a></li>
-						    <li><a href="<%=__base_url%>/prob/incomplete/<%= rels[i]._id %>">Incomplete</a></li>
+						    <li><a href="/prob/complete/<%= rels[i]._id %>">Complete</a></li>
+						    <li><a href="/prob/incomplete/<%= rels[i]._id %>">Incomplete</a></li>
 						  </ul>
 						</div>
 

--- a/views/template/common/footer.ejs
+++ b/views/template/common/footer.ejs
@@ -53,7 +53,7 @@
 				});
 			<% } %>
 			<% if(main_page.split("/").reverse()[1] == "challenge"){ %>
-				var challenge = io.connect("<%=base_url%>/challenge");
+				var challenge = io.connect("/challenge");
 
 				function setJoinRoom(room_number){
 					$('tr[class^=room_].clicked').removeClass('clicked');
@@ -99,7 +99,7 @@
 				challenge.on('create_challenge_response', function(data){
 					if(data.response == "success"){
 						// Redirect to the new room
-						window.location.href = "<%=base_url%>/challenge/room/"+data.room_number;
+						window.location.href = "/challenge/room/"+data.room_number;
 					}
 				});
 
@@ -133,7 +133,7 @@
 				}
 			<% } %>
 			<% if(main_page.split("/").reverse()[2] + "/" + main_page.split("/").reverse()[1] == "challenge/room"){ %>
-				var challenge_room = io.connect("<%=base_url%>/challenge");
+				var challenge_room = io.connect("/challenge");
 			<% } %>
 		</script> 
 	</body>

--- a/views/template/user/menu.ejs
+++ b/views/template/user/menu.ejs
@@ -2,8 +2,8 @@
 	<div class="col-md-12">
 
 		<span class="logo-menu col-md-4">
-		<img src="<%=__base_url%>/favicon.ico" class="menubar-icon"/>
-		&nbsp;&nbsp;&nbsp;&nbsp;<a href="<%=__base_url%>">Algorithm Time</a></span>
+		<img src="/favicon.ico" class="menubar-icon"/>
+		&nbsp;&nbsp;&nbsp;&nbsp;<a href="/">Algorithm Time</a></span>
 
 		<div class="text-right col-md-8">
 			<ul class="nav nav-pills">
@@ -15,38 +15,38 @@
 					    <%= user.fullname %>&nbsp;&nbsp; <span class="caret"></span>
 					  </button>
 					  <ul class="dropdown-menu">
-					    <li><a href="<%=__base_url%>/user/profile">Profile</a></li>
+					    <li><a href="/user/profile">Profile</a></li>
 
 					    <% if(user.level == level.ADMIN){ %>
-					    	<li><a href="<%=__base_url%>/room/create">Create Room</a></li>
-					    	<li><a href="<%=__base_url%>/submissions">Submissions</a></li>
-					    	<li><a href="<%=__base_url%>/admin">Admin panel</a></li>
+					    	<li><a href="/room/create">Create Room</a></li>
+					    	<li><a href="/submissions">Submissions</a></li>
+					    	<li><a href="/admin">Admin panel</a></li>
 					    <% } %>
 
 					    <li role="separator" class="divider"></li>
-					    <li><a href="<%=__base_url%>/user/logout">Logout</a></li>
+					    <li><a href="/user/logout">Logout</a></li>
 					  </ul>
 					</div>
 					<li role="presentation" 
 					<% if(main_page.split("/").pop() == "all" && main_page.split("/")[main_page.split("/").length-2] == "room"){ %> class="active" <% } %>>
-					<a href="<%=__base_url%>/room/all">
+					<a href="/room/all">
 					<span class="glyphicon glyphicon-education" aria-hidden="true"></span>&nbsp;&nbsp;Rooms</a></li>
 				<% } %>	
 				<li role="presentation" 
 				<% if(main_page.split("/").pop() == "leaderboard"){ %> class="active" <% } %>
-				><a href="<%=__base_url%>/leaderboard">
+				><a href="/leaderboard">
 				<span class="glyphicon glyphicon-fire" aria-hidden="true"></span>&nbsp;&nbsp;Leaderboard</a></li>
 				<!--
 				<% if(loggedIn == true){ %>
 				<li role="presentation"
 				<% if(main_page.split("/").reverse()[1] == "challenge"){ %> class="active" <% } %>
-				><a href="<%=__base_url%>/challenge">
+				><a href="/challenge">
 				<span class="glyphicon glyphicon-knight" aria-hidden="true"></span>&nbsp;&nbsp;Challenge</a></li>
 				<% } %>
 				-->
 				<li role="presentation" 
 				<% if(main_page.split("/").pop() == "index" && main_page.split("/").reverse()[1] != "challenge" && main_page.split("/")[main_page.split("/").length-2] != "room" && main_page.split("/")[main_page.split("/").length-2] != "prob"){ %> class="active" <% } %>
-				><a href="<%=__base_url%>">
+				><a href="/">
 				<span class="glyphicon glyphicon-home" aria-hidden="true"></span>&nbsp;&nbsp;Home</a></li>
 			</ul>
 		</div>

--- a/views/user/edit.ejs
+++ b/views/user/edit.ejs
@@ -4,7 +4,7 @@
 			<h3 >Edit profile</h3>
 		</div>
 
-		<form method="POST" action="<%=base_url%>/user/edit/<%=profile.nickname%>">
+		<form method="POST" action="/user/edit/<%=profile.nickname%>">
 
 			<% if(typeof success_msg != 'undefined') { %>
 			<div class="top-messages bg-success"><%= success_msg %></div>
@@ -44,7 +44,7 @@
 			<%}%>
 			<div class="text-danger form-group">* Required field</div>
 			<button type="submit" class="btn btn-default">Save</button>
-			<a href="<%=base_url%>/user/profile/<%=profile.nickname%>" class="btn btn-default">Cancel</a>
+			<a href="/user/profile/<%=profile.nickname%>" class="btn btn-default">Cancel</a>
 		</form>
 	</div>
 </div>

--- a/views/user/profile.ejs
+++ b/views/user/profile.ejs
@@ -1,7 +1,7 @@
 <div class="col-md-offset-2 col-md-8">
 	<div class="user-profile">
 		<div class="main-title-profile text-center">
-			<h2><b><%=profile.fullname%></b> <span class="small"><i>(<%=profile.nickname%>)</i></span> <% if(user.level == level.ADMIN || (user.nickname == profile.nickname && user.level == level.USER)){%><a href="<%=base_url%>/user/edit/<%=profile.nickname%>" style="font-size:12px;" class="label label-info">Edit profile</a><%}%></h2>
+			<h2><b><%=profile.fullname%></b> <span class="small"><i>(<%=profile.nickname%>)</i></span> <% if(user.level == level.ADMIN || (user.nickname == profile.nickname && user.level == level.USER)){%><a href="/user/edit/<%=profile.nickname%>" style="font-size:12px;" class="label label-info">Edit profile</a><%}%></h2>
 			<h3>Total Points</h3>
 			<h4><span class="glyphicon glyphicon-star" aria-hidden="true"></span><%= profile.score %></h4>
 		</div>
@@ -23,7 +23,7 @@
 								<td><%= (i+1) %></td>
 								<td><%= profile.problems[i].prob_docs[0].title %></td>
 								<td><%= profile.problems[i].score %></td>
-								<td><a href="<%=base_url%>/prob/<%= profile.problems[i].prob %>" class="label label-info">View problem</a></td>
+								<td><a href="/prob/<%= profile.problems[i].prob %>" class="label label-info">View problem</a></td>
 							</tr>
 						<% } %>
 					<% }else{ %>


### PR DESCRIPTION
All `href`s across the code base were being hardcoded with the absolute link `https://localhost:3000`.

This broke all links for users once the production server was set up.

Solution is to use relative links instead.